### PR TITLE
Read Supabase env vars from Vite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment variables for Track N Thrive App
+SUPABASE_URL=
+SUPABASE_PUBLISHABLE_KEY=
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Environment variables
+
+Create a `.env` file based on `.env.example` and provide your Supabase
+credentials:
+
+```env
+SUPABASE_URL=<your-supabase-url>
+SUPABASE_PUBLISHABLE_KEY=<your-supabase-key>
+```
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/fd86b769-71df-425a-a3b4-a077107181b6) and click on Share -> Publish.

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://wmsxnktgzffqgihusjei.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indtc3hua3RnemZmcWdpaHVzamVpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg2ODI3MDksImV4cCI6MjA2NDI1ODcwOX0.nhJ2pzaDr1YqeLSfGL3T1nW_cWduIC8eREqfKM6lXrI";
+const SUPABASE_URL = import.meta.env.SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.SUPABASE_PUBLISHABLE_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,12 +11,12 @@ export default defineConfig(({ mode }) => ({
   },
   plugins: [
     react(),
-    mode === 'development' &&
-    componentTagger(),
+    mode === 'development' && componentTagger(),
   ].filter(Boolean),
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  envPrefix: ["VITE_", "SUPABASE_"]
 }));


### PR DESCRIPTION
## Summary
- read Supabase config from env variables
- expose SUPABASE_ variables in Vite config
- document required env vars and provide `.env.example`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6842dc6d4d98832ebb2009a68373a102